### PR TITLE
HTTP timeout settings are configurable

### DIFF
--- a/lib/convoy/api_operations/request.rb
+++ b/lib/convoy/api_operations/request.rb
@@ -37,14 +37,7 @@ module Convoy
         end
 
         # Build HTTP Client.
-        client = Net::HTTP.new(uri.host, uri.port)
-        client.use_ssl = config.ssl
-        client.open_timeout = 10
-        client.read_timeout = 10
-        client.continue_timeout = 10
-        client.ssl_timeout = 10
-
-        client.set_debug_output $stderr if config.debug
+        client = build_http_client(uri, config)
 
         # Make request.
         http_response = client.request(request)
@@ -52,6 +45,22 @@ module Convoy
 
         self
         # TODO: Perform err checks.
+      end
+
+      private
+
+      def build_http_client(uri, config)
+        client = Net::HTTP.new(uri.host, uri.port)
+
+        client.use_ssl = config.ssl
+        client.open_timeout = config.http_open_timeout
+        client.read_timeout = config.http_read_timeout
+        client.continue_timeout = config.http_continue_timeout
+        client.ssl_timeout = config.http_ssl_timeout
+
+        client.set_debug_output $stderr if config.debug
+
+        client
       end
     end
   end

--- a/lib/convoy/convoy_configuration.rb
+++ b/lib/convoy/convoy_configuration.rb
@@ -9,12 +9,20 @@ module Convoy
     attr_accessor :logger
     attr_accessor :log_level
     attr_accessor :project_id
+    attr_accessor :http_open_timeout
+    attr_accessor :http_read_timeout
+    attr_accessor :http_continue_timeout
+    attr_accessor :http_ssl_timeout
 
     def initialize
       @base_uri = "https://dashboard.getconvoy.io/api"
       @path_version = "/v1"
       @ssl = true
       @debug = false
+      @http_open_timeout = 10
+      @http_read_timeout = 10
+      @http_continue_timeout = 10
+      @http_ssl_timeout = 10
     end
 
   end


### PR DESCRIPTION
This adds

- `http_open_timeout`
- `http_read_timeout`
- `http_continue_timeout`
- `http_ssl_timeout`

to `ConvoyConfiguration` and uses them when initializing the HTTP client in `Convoy::ApiOperations::Request#send_request`.

This allows configuring the timeouts as seen fit by the integrator.