### PR TITLE
Add delegators to new HTTP timeout configs to Convoy module

### DIFF
--- a/lib/convoy.rb
+++ b/lib/convoy.rb
@@ -29,5 +29,9 @@ module Convoy
     def_delegators :@config, :log_level, :log_level=
     def_delegators :@config, :path_version, :path_version=
     def_delegators :@config, :project_id, :project_id=
+    def_delegators :@config, :http_open_timeout, :http_open_timeout=
+    def_delegators :@config, :http_read_timeout, :http_read_timeout=
+    def_delegators :@config, :http_continue_timeout, :http_continue_timeout=
+    def_delegators :@config, :http_ssl_timeout, :http_ssl_timeout=
   end
 end


### PR DESCRIPTION
This is missing to actually allow setting the HTTP timeouts without accessing the `@config` instance variable directly.